### PR TITLE
[JVM] script.sh, jvm action 오타 수정 및 action cache 해제

### DIFF
--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        images: [jre, jdk]
+        image: [jre, jdk]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -32,20 +32,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker Metadata action(${{ matrix.images }})
+      - name: Docker Metadata action(${{ matrix.image }})
         id: meta
         uses: docker/metadata-action@v4.3.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.images }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image }}
           tags: |
             type=semver,pattern={{version}}
 
-      - name: Build and push Docker image(${{ matrix.images }})
+      - name: Build and push Docker image(${{ matrix.image }})
         uses: docker/build-push-action@v4.0.0
         with:
           platforms: linux/amd64,linux/arm64
           context: jvm/
-          file: jvm/jre.Dockerfile
+          file: jvm/${{ matrix.image }}.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/jvm.yml
+++ b/.github/workflows/jvm.yml
@@ -48,5 +48,4 @@ jobs:
           file: jvm/jre.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+

--- a/jvm/script.sh
+++ b/jvm/script.sh
@@ -3,8 +3,8 @@ export GRPC_HEALTH_PROBE_VERSION=v0.4.14
 
 ARCH=""
 case $(arch) in
-    x86_64) ARCH="amd64" ;;
-    aarch64) ARCH="arm64" ;;
+    x86_64) ARCH=amd64 ;;
+    aarch64) ARCH=arm64 ;;
 esac
 
 echo $ARCH
@@ -15,5 +15,6 @@ apt-get install -y wget
 
 wget -O /dd-java-agent.jar https://dtdg.co/latest-java-tracer
 
-wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-{$ARCH}
+wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${ARCH}
 chmod +x /bin/grpc_health_probe
+


### PR DESCRIPTION
action cache를 해제하는 이유는 지금과 같이 잘못된 것이 캐싱되면 좋지 않고, 많이 호출되는 action이 아니기 때문에 굳이 캐싱할 이유도 없기 때문입니다.