### PR TITLE
[JVM] jdk 21 & grpc health probe 0.4.23

### DIFF
--- a/jvm/jdk.Dockerfile
+++ b/jvm/jdk.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:19.0.2_7-jdk
+FROM eclipse-temurin:21.0.1_12-jdk
 
 WORKDIR /
 

--- a/jvm/jre.Dockerfile
+++ b/jvm/jre.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:19.0.2_7-jre
+FROM eclipse-temurin:21.0.1_12-jre
 
 WORKDIR /
 

--- a/jvm/script.sh
+++ b/jvm/script.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export GRPC_HEALTH_PROBE_VERSION=v0.4.14
+export GRPC_HEALTH_PROBE_VERSION=v0.4.23
 
 ARCH=""
 case $(arch) in
@@ -17,4 +17,3 @@ wget -O /dd-java-agent.jar https://dtdg.co/latest-java-tracer
 
 wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${ARCH}
 chmod +x /bin/grpc_health_probe
-


### PR DESCRIPTION
Java 21이 LTS가 되고 temurin 21이 나옴에 따라 업데이트된 이미지를 작성합니다.

grpc health probe는 dependency 업데이트 정도고 저희가 신경 쓸 변경점은 없어 보입니다.